### PR TITLE
Add Toggl integration

### DIFF
--- a/src/options/components/TogglSection.js
+++ b/src/options/components/TogglSection.js
@@ -27,9 +27,22 @@ export default function TogglSection() {
     setConfig(config);
   }
 
+  const breakTagsToText = () => config.breakTags.join(', ');
+  /**
+   * @param {string} text
+   * @returns {string[]}
+   */
+  const textToBreakTags = text => text.split(',')
+    .map(t => t.trim())
+    .filter(t => t);
+
   return (
     <div>
-      <h3 className="settings__header">Toggl Integration Settings</h3>
+      <h3 className="toggl__header">Toggl Integration Settings</h3>
+      <p className="toggl__subheader">
+        Allow access to blocked websites when you're tracking a break in
+        <a className="toggl__link" href="https://toggl.com" target="_blank">Toggl</a>
+      </p>
       <hr />
       {config &&
         <form>
@@ -47,8 +60,17 @@ export default function TogglSection() {
             <input
               name="token"
               type="text"
-              checked={config.token}
+              value={config.token}
               onChange={e => updateConfig({ ...config, token: e.target.value })}
+            />
+          </div>
+          <div className="form-group">
+            <label className="mr-2" htmlFor="breakTags">Break tags (comma separated)</label>
+            <input
+              name="breakTags"
+              type="text"
+              value={breakTagsToText()}
+              onChange={e => updateConfig({ ...config, token: textToBreakTags(e.target.value) })}
             />
           </div>
         </form>

--- a/src/options/components/TogglSection.js
+++ b/src/options/components/TogglSection.js
@@ -1,0 +1,58 @@
+import React, { useEffect, useState } from 'react';
+import StorageHandler from '../../storage/StorageHandler';
+
+/**
+ * @typedef {Object} TogglConfig
+ * @property {boolean} enabled
+ * @property {string} token
+ * @property {string[]} breakTags
+ */
+
+export default function TogglSection() {
+  /**
+   * @type {[TogglConfig, (togglConfig: TogglConfig) => void]}
+   */
+  const [config, setConfig] = useState();
+  console.log('config', config);
+
+  useEffect(() => {
+    StorageHandler.getTogglConfig().then(setConfig);
+  }, []);
+
+  /**
+   * @param {TogglConfig} config
+   */
+  async function updateConfig(config) {
+    await StorageHandler.setTogglConfig(config);
+    setConfig(config);
+  }
+
+  return (
+    <div>
+      <h3 className="settings__header">Toggl Integration Settings</h3>
+      <hr />
+      {config &&
+        <form>
+          <div className="form-group">
+            <label htmlFor="enabledButton">Enable Toggl integration</label>
+            <input
+              name="enabledButton"
+              type="checkbox"
+              checked={config.enabled}
+              onChange={e => updateConfig({ ...config, enabled: !!e.target.value })}
+            />
+          </div>
+          <div className="form-group">
+            <label htmlFor="token">Toggl API token</label>
+            <input
+              name="token"
+              type="text"
+              checked={config.token}
+              onChange={e => updateConfig({ ...config, token: e.target.value })}
+            />
+          </div>
+        </form>
+      }
+    </div>
+  );
+}

--- a/src/options/index.js
+++ b/src/options/index.js
@@ -6,6 +6,7 @@ import MessageTypes from '../enums/messages';
 import DomainListItem from './components/DomainListItem';
 import SettingsSection from './components/SettingsSection';
 import ExtensionStatus from './components/ExtensionStatus';
+import TogglSection from './components/TogglSection';
 
 class Options extends React.Component {
   constructor(props) {
@@ -153,6 +154,7 @@ class Options extends React.Component {
             <hr />
             <ul className="blocklist__list">{this.listItems()}</ul>
           </div>
+          <TogglSection />
           <SettingsSection />
         </div>
       </div>

--- a/src/options/options.css
+++ b/src/options/options.css
@@ -178,3 +178,16 @@ hr {
     font-size: 20px;
   }
 }
+
+.toggl__header {
+  font-size: 1.8rem;
+  color: #1a1a1a;
+}
+
+.toggl__subheader {
+  margin: 0;
+}
+
+.toggl__link {
+  margin-left: 0.2em;
+}

--- a/src/options/options.css
+++ b/src/options/options.css
@@ -191,3 +191,13 @@ hr {
 .toggl__link {
   margin-left: 0.2em;
 }
+
+.toggl__text-input {
+  margin-left: 0.4em;
+  width: 20em;
+}
+
+.toggl__save {
+  margin-left: 0;
+  margin-top: 0.2em;
+}

--- a/src/storage/StorageHandler.js
+++ b/src/storage/StorageHandler.js
@@ -20,6 +20,37 @@ export default class StorageHandler {
     return browser.storage.local.get('sites');
   }
 
+
+  /**
+   * @typedef {Object} TogglConfig
+   * @property {boolean} enabled
+   * @property {string} token
+   * @property {string[]} breakTags
+   */
+
+  /**
+   * @returns {Promise<TogglConfig>}
+   */
+  static async getTogglConfig() {
+    const storage = await browser.storage.local.get('togglConfig');
+    return storage.togglConfig || {
+      enabled: false,
+      token: '',
+      breakTags: [
+        'pomodoro-break',
+        'break',
+      ],
+    };
+  }
+
+  /**
+   *
+   * @param {TogglConfig} togglConfig
+   */
+  static setTogglConfig(togglConfig) {
+    return browser.storage.local.set({ togglConfig });
+  }
+
   static async isDomainBlocked(urlToMatch) {
     const websites = await StorageHandler.getWebsiteDomains();
     return websites.includes(urlToMatch);

--- a/src/utils/functions.js
+++ b/src/utils/functions.js
@@ -17,12 +17,10 @@ export async function redirectToBlockedPage(requestDetails) {
 
   const togglConfig = await StorageHandler.getTogglConfig();
   if (togglConfig.enabled && await isOnBreak(togglConfig)) {
-    console.log('cancelling redirect');
-    return {};
+    return;
   }
 
   browser.tabs.update(requestDetails.tabId, { url: interceptPage });
-  return {};
 }
 
 export function backgroundResponse(value) {

--- a/src/utils/functions.js
+++ b/src/utils/functions.js
@@ -1,14 +1,52 @@
+/**
+ * @typedef {Object} TogglConfig
+ * @property {boolean} enabled
+ * @property {string} token
+ * @property {string[]} breakTags
+ */
+import StorageHandler from "../storage/StorageHandler";
+
 export function openOptionsPage() {
   browser.runtime.openOptionsPage();
   window.close();
 }
 
-export function redirectToBlockedPage(requestDetails) {
+export async function redirectToBlockedPage(requestDetails) {
   const original = encodeURIComponent(requestDetails.url);
   const interceptPage = `/resources/redirect.html?target=${original}`;
+
+  const togglConfig = await StorageHandler.getTogglConfig();
+  if (togglConfig.enabled && await isOnBreak(togglConfig)) {
+    console.log('cancelling redirect');
+    return {};
+  }
+
   browser.tabs.update(requestDetails.tabId, { url: interceptPage });
+  return {};
 }
 
 export function backgroundResponse(value) {
   return new Promise(res => res(value));
+}
+
+/**
+ * @param togglConfig {TogglConfig}
+ * @returns {Promise<boolean>}
+ */
+async function isOnBreak(togglConfig) {
+  const endpoint = 'https://www.toggl.com/api/v8/time_entries/current';
+  const auth = `Basic ${btoa(`${togglConfig.token}:api_token`)}`;
+
+  const response = await fetch(endpoint, {
+    headers: new Headers({
+      Authorization: auth
+    })
+  });
+  if (!response.ok) return false;
+
+  const body = await response.json();
+  if (!body.data) return false;
+
+  const breakTags = new Set(togglConfig.breakTags);
+  return body.data.tags.some(tag => breakTags.has(tag));
 }


### PR DESCRIPTION
I thought it would be cool if there was a site blocker with a toggl integration.

Now, when you try to visit a blocked site, the extension checks toggl to see if you're on a break. If you are, it lets you through to visit the blocked site. I plan on not showing the disable and pause buttons in the popup. That way if I want to procastinate, I have to either track it or manually disable the blocker through settings. Either way it's a bit off a hassle unless I'm already on a break.

No hard feelings if you're not interested in merging something like this. It is a bit of change in scope. I just thought I'd give you the option. Thanks for your work by the way. It was super easy to make the changes I needed.