### PR TITLE
Persist pause state

### DIFF
--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "Impulse Blocker",
-  "version": "1.1.6",
+  "version": "1.1.7",
   "manifest_version": 2,
   "description": "Block distracting websites when you are browsing the web.",
   "permissions": [

--- a/src/ImpulseBlocker.js
+++ b/src/ImpulseBlocker.js
@@ -49,8 +49,9 @@ export default class ImpulseBlocker {
     return this.start();
   }
 
-  setPausedUntil(datetime) {
+  async setPausedUntil(datetime) {
     this.pausedUntil = datetime;
+    return StorageHandler.setPausedUntil(datetime);
   }
 
   getPausedUntil() {

--- a/src/background.js
+++ b/src/background.js
@@ -13,6 +13,14 @@ const blocker = new ImpulseBlocker();
 StorageHandler.getExtensionStatus().then(storage => {
   if (storage.status === ExtensionStatus.ON) {
     blocker.start();
+  } else if (storage.status === ExtensionStatus.PAUSED) {
+    const pausedUntil = StorageHandler.getPausedUntil();
+    
+    // get current date time
+    // get difference in seconds
+    // if positive then pause
+    // if negavite start the extension
+    blocker.pause(pausedUntil.seconds);
   } else {
     blocker.stop();
   }

--- a/src/storage/StorageHandler.js
+++ b/src/storage/StorageHandler.js
@@ -4,11 +4,11 @@ export default class StorageHandler {
   static async getWebsiteDomainsAsMatchPatterns() {
     const { sites } = await StorageHandler.getBlockedWebsites();
 
-    return new Promise((resolve, reject) => {
+    return new Promise(resolve => {
       const mappedWebsites = sites.map(website => `*://*.${website.domain}/*`);
 
       resolve(mappedWebsites);
-    });
+    })
   }
 
   static async getWebsiteDomains() {
@@ -55,6 +55,18 @@ export default class StorageHandler {
     return browser.storage.local.set({
       status,
     });
+  }
+
+  static async setPausedUntil(datetime) {
+    console.log('setting paused until');
+    console.log(datetime.toISOString());
+    return browser.storage.local.set({
+      pausedUntil: datetime.toISOString(),
+    });
+  }
+
+  static async getPausedUntil() {
+    return browser.storage.local.get('pausedUntil');
   }
 
   static getExtensionSettings() {

--- a/src/storage/StorageHandler.js
+++ b/src/storage/StorageHandler.js
@@ -8,7 +8,7 @@ export default class StorageHandler {
       const mappedWebsites = sites.map(website => `*://*.${website.domain}/*`);
 
       resolve(mappedWebsites);
-    })
+    });
   }
 
   static async getWebsiteDomains() {
@@ -58,14 +58,12 @@ export default class StorageHandler {
   }
 
   static async setPausedUntil(datetime) {
-    console.log('setting paused until');
-    console.log(datetime.toISOString());
     return browser.storage.local.set({
       pausedUntil: datetime.toISOString(),
     });
   }
 
-  static async getPausedUntil() {
+  static getPausedUntil() {
     return browser.storage.local.get('pausedUntil');
   }
 


### PR DESCRIPTION
Fixes: #41, #54

### Description

Currently, if you start a pause with the extension and then close your browser, the paused state will be lost. After the restart, the extension will not be paused.

This is not actually bug, but an oversight on my part. Since the I have never thought about that case. 

### Changes

Now the `pausedUntil` time will be saved to the local storage. When the extension starts (i.e. browser is opened) it will check that value to determine the current state. 

### Notes

Very bad implementation, but I'll let that one slip as I'm planning to improve the code in the future. We also need some test since adding new features are becoming a bit of a hassle. 